### PR TITLE
feature: use `--entryFile` as default `--outputFileName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install `esnow` with npm.
 npm install esnow --save-dev
 ```
 
-Add an `esnow` call it to your package.json `scripts` field. Specify your entryfile with the `-e` option and the output folder with the `-o` option. `esnow` will produce an `app.js` and an `app.js.map` in your output folder.
+Add an `esnow` call it to your package.json `scripts` field. Specify your entryfile with the `-e` option and the output folder with the `-o` option. `esnow` will produce an `main.js` and an `main.js.map` in your output folder.
 
 ```js
 "scripts": {
@@ -98,7 +98,7 @@ Enjoy writing **ESXXXX** code with Node packages and debugging it easily via sou
      --entryFile, -e  Path to the entry file (required).
          --watch, -w  Watch and compile your files with watchify.
           --prod, -p  Production mode (minifies the code).
---outputFileName, -f  Name of the output file defaults to "app.js".
+--outputFileName, -f  Name of the output file defaults to `--entryFile`.
 ```
 
 ## Todo

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,9 +6,9 @@ var argv = require('minimist')(process.argv.slice(2));
 var esnow = require('../lib/');
 
 // Parse command line options.
-var outputFileName = argv.outputFileName || argv.f || 'app.js';
-var outputPath = argv.outputPath || argv.o || '';
 var entryFile = argv.entryFile || argv.e || '';
+var outputFileName = argv.outputFileName || argv.f || path.basename(entryFile);
+var outputPath = argv.outputPath || argv.o || '';
 var outputFile = path.join(process.cwd(), outputPath, outputFileName);
 var prod = argv.prod || argv.p || false;
 var watch = argv.watch || argv.w || false;

--- a/test/test.js
+++ b/test/test.js
@@ -5,9 +5,9 @@ var spawn = require('child_process').spawn;
 var isThere = require('is-there');
 var testCompile = spawn('npm', ['run', 'test-compile']);
 
-var paths = ['test/fixtures/out/app.js', 'test/fixtures/out/app.js.map'];
+var paths = ['test/fixtures/out/main.js', 'test/fixtures/out/main.js.map'];
 
-test('should generate app.js and app.js.map', function(t) {
+test('should generate main.js and main.js.map', function(t) {
   t.plan(2);
 
   testCompile.on('close', function(code) {


### PR DESCRIPTION
Use `--entryFile` as default `--outputFileName`  instead of `app.js`.
